### PR TITLE
idempotent unescape

### DIFF
--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -18,7 +18,7 @@ __all__ = ['Markup', 'soft_unicode', 'escape', 'escape_silent']
 
 
 _striptags_re = re.compile(r'(<!--.*?-->|<[^>]*>)')
-_entity_re = re.compile(r'&([^;]+);')
+_entity_re = re.compile(r'&([^& ;]+);')
 
 
 class Markup(text_type):
@@ -140,7 +140,8 @@ class Markup(text_type):
                     return unichr(int(name[1:]))
             except ValueError:
                 pass
-            return u''
+            # Don't modify unexpected input.
+            return m.group()
         return _entity_re.sub(handle_match, text_type(self))
 
     def striptags(self):

--- a/markupsafe/tests.py
+++ b/markupsafe/tests.py
@@ -60,10 +60,22 @@ class MarkupTestCase(unittest.TestCase):
         }, Markup(u'<em>&lt;foo&gt;:&lt;bar&gt;</em>'))
 
     def test_escaping(self):
-        # escaping and unescaping
+        # escaping
         assert escape('"<>&\'') == '&#34;&lt;&gt;&amp;&#39;'
         assert Markup("<em>Foo &amp; Bar</em>").striptags() == "Foo & Bar"
+
+    def test_unescape(self):
         assert Markup("&lt;test&gt;").unescape() == "<test>"
+        assert "jack & tavi are cooler than mike & russ" == \
+                Markup("jack & tavi are cooler than mike &amp; russ").unescape(), \
+                Markup("jack & tavi are cooler than mike &amp; russ").unescape()
+
+        # Test that unescape is idempotent
+        original = '&foo&#x3b;'
+        once = Markup(original).unescape()
+        twice = Markup(once).unescape()
+        expected = "&foo;"
+        assert expected == once == twice, (once, twice)
 
     def test_formatting(self):
         for actual, expected in (


### PR DESCRIPTION
I added a failing test. Note that the current implementation deletes the middle portion of the text.

```
======================================================================
FAIL: test_unescape (markupsafe.tests.MarkupTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/nail/home/buck/trees/theirs/markupsafe/markupsafe/tests.py", line 71, in test_unescape
    Markup("jack & tavi are cooler than mike &amp; russ").unescape()
AssertionError: jack  russ

----------------------------------------------------------------------
Ran 13 tests in 0.181s
```

Altering the regex fixes this issue.
Secondarily, the current implemetation will delete anything that *looks* like an html entity but is not:

```
======================================================================
FAIL: test_unescape (markupsafe.tests.MarkupTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/nail/home/buck/trees/theirs/markupsafe/markupsafe/tests.py", line 78, in test_unescape
    assert expected == once == twice, (once, twice)
AssertionError: (u'&foo;', u'')

----------------------------------------------------------------------
Ran 13 tests in 0.171s
```