### PR TITLE
Added SystemError as possible compiling error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,16 @@ for arg in '--with-speedups', '--without-speedups':
         pass
 
 
+# Known errors when running build_ext.build_extension method
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
 if sys.platform == 'win32' and sys.version_info > (2, 6):
     # 2.6's distutils.msvc9compiler can raise an IOError when failing to
     # find the compiler
     ext_errors += (IOError,)
+# Known errors when running build_ext.run method
+run_errors = (DistutilsPlatformError,)
+if sys.platform == 'darwin':
+    run_errors += (SystemError,)
 
 
 class BuildFailed(Exception):
@@ -39,7 +44,7 @@ class ve_build_ext(build_ext):
     def run(self):
         try:
             build_ext.run(self)
-        except DistutilsPlatformError:
+        except run_errors:
             raise BuildFailed()
 
     def build_extension(self, ext):


### PR DESCRIPTION
Python.org Python raises a SystemError for a missing compiler when running
"customize_compiler" so before the "build_extension" method for which other
errors get trapped. Look also for SystemError when running build_ext.run
method to check for this.