### PR TITLE
Add __version__

### DIFF
--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -14,6 +14,7 @@ from collections import Mapping
 from markupsafe._compat import text_type, string_types, int_types, \
      unichr, iteritems, PY2
 
+__version__ = "0.23"
 
 __all__ = ['Markup', 'soft_unicode', 'escape', 'escape_silent']
 


### PR DESCRIPTION
Added \__version__ attr to package so that scripts that check local
packages to see if newer versions are available can work.

Almost all Python packages have a version attr, and the vast majority of
them name it "\__version__"