### PR TITLE
Explicitly trigger GC prior to counting; fixes #39.

### DIFF
--- a/markupsafe/tests.py
+++ b/markupsafe/tests.py
@@ -158,6 +158,7 @@ class MarkupLeakTestCase(unittest.TestCase):
                 escape("<foo>")
                 escape(u"foo")
                 escape(u"<foo>")
+            gc.collect()
             counts.add(len(gc.get_objects()))
         assert len(counts) == 1, 'ouch, c extension seems to leak objects'
 

--- a/markupsafe/tests.py
+++ b/markupsafe/tests.py
@@ -158,9 +158,9 @@ class MarkupLeakTestCase(unittest.TestCase):
                 escape("<foo>")
                 escape(u"foo")
                 escape(u"<foo>")
-            gc.collect()
+            if hasattr(sys, 'pypy_version_info'): gc.collect()
             counts.add(len(gc.get_objects()))
-        assert len(counts) == 1, 'ouch, c extension seems to leak objects'
+        assert len(counts) == 1, 'ouch, c extension seems to leak objects, got: ' + str(len(counts))
 
 
 def suite():


### PR DESCRIPTION
Thanks to a touch of assistance from #pypy, an explicit call to `gc.collect()` will force the objects to be collected rather than letting the runtime defer cleanup to some indeterminate future time.

**Huge warning:** This is *not* guaranteed to continue working in future pypy versions.  Attempting to manipulate the GC is generally an Unwise Thing to Do™, Not Portable Between Runtimes™, and not too dissimilar to direct manipulation of the GIL.  It'll probably be fine, but pypy supports modular GC policies and this has only been tested under the default policy.