### PR TITLE
Fix an error without compilers on OS X

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class ve_build_ext(build_ext):
     def run(self):
         try:
             build_ext.run(self)
-        except DistutilsPlatformError:
+        except (DistutilsPlatformError, SystemError):
             raise BuildFailed()
 
     def build_extension(self, ext):


### PR DESCRIPTION
The error was : 

```
Downloading/unpacking markupsafe (from jinja2->patacrep)
  Downloading MarkupSafe-0.23.tar.gz
  Running setup.py (path:/private/var/folders/nk/ttcg4b211z9744dt39gfpjmh0000gn/T/pip_build_sergekottelat/markupsafe/setup.py) egg_info for package markupsafe
    
Installing collected packages: markupsafe
  Running setup.py install for markupsafe
    
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/nk/ttcg4b211z9744dt39gfpjmh0000gn/T/pip_build_sergekottelat/markupsafe/setup.py", line 120, in <module>
        try_building_extension()
      File "/private/var/folders/nk/ttcg4b211z9744dt39gfpjmh0000gn/T/pip_build_sergekottelat/markupsafe/setup.py", line 99, in try_building_extension
        run_setup(True)
      File "/private/var/folders/nk/ttcg4b211z9744dt39gfpjmh0000gn/T/pip_build_sergekottelat/markupsafe/setup.py", line 93, in run_setup
        ext_modules=ext_modules,
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/site-packages/setuptools/command/install.py", line 54, in run
        return _install.run(self)
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/command/install.py", line 539, in run
        self.run_command('build')
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/command/build.py", line 126, in run
        self.run_command(cmd_name)
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/cmd.py", line 313, in run_command
        self.distribution.run_command(command)
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/dist.py", line 974, in run_command
        cmd_obj.run()
      File "/private/var/folders/nk/ttcg4b211z9744dt39gfpjmh0000gn/T/pip_build_sergekottelat/markupsafe/setup.py", line 41, in run
        build_ext.run(self)
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/command/build_ext.py", line 309, in run
        customize_compiler(self.compiler)
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/distutils/sysconfig.py", line 182, in customize_compiler
        _osx_support.customize_compiler(_config_vars)
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/_osx_support.py", line 418, in customize_compiler
        _find_appropriate_compiler(_config_vars)
      File "/Library/Frameworks/Python.framework/Versions/3.4/lib/python3.4/_osx_support.py", line 191, in _find_appropriate_compiler
        "Cannot locate working compiler")
    SystemError: Cannot locate working compiler
```

and came out on OS X 10.8, when no compilers are disponibles. Tell me if you prefer another place for catching the exception.