### PR TITLE
Restore speedups feature

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from setuptools import setup, Extension
+from setuptools import setup, Extension, Feature
 from distutils.command.build_ext import build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, \
      DistutilsPlatformError
@@ -12,6 +12,14 @@ from distutils.errors import CCompilerError, DistutilsExecError, \
 is_jython = 'java' in sys.platform
 is_pypy = hasattr(sys, 'pypy_version_info')
 
+
+speedups = Feature(
+    'optional C speed-enhancement module',
+    standard=True,
+    ext_modules = [
+        Extension('markupsafe._speedups', ['markupsafe/_speedups.c']),
+    ],
+)
 
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
 if sys.platform == 'win32' and sys.version_info > (2, 6):
@@ -53,8 +61,9 @@ readme = open(os.path.join(os.path.dirname(__file__), 'README.rst')).read()
 
 
 def run_setup(with_binary):
-    ext = Extension('markupsafe._speedups', ['markupsafe/_speedups.c'])
-    ext_modules = [ext] if with_binary else []
+    features = {}
+    if with_binary:
+        features['speedups'] = speedups
     setup(
         name='MarkupSafe',
         version='0.23',
@@ -81,7 +90,7 @@ def run_setup(with_binary):
         test_suite='markupsafe.tests.suite',
         include_package_data=True,
         cmdclass={'build_ext': ve_build_ext},
-        ext_modules=ext_modules,
+        features=features,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -13,15 +13,6 @@ is_jython = 'java' in sys.platform
 is_pypy = hasattr(sys, 'pypy_version_info')
 
 
-# Remove old arguments that were once supported.  Thanks setuptools
-# 3.0 for just randomly removing functionality.
-for arg in '--with-speedups', '--without-speedups':
-    try:
-        sys.argv.remove(arg)
-    except ValueError:
-        pass
-
-
 ext_errors = (CCompilerError, DistutilsExecError, DistutilsPlatformError)
 if sys.platform == 'win32' and sys.version_info > (2, 6):
     # 2.6's distutils.msvc9compiler can raise an IOError when failing to


### PR DESCRIPTION
"Features" were removed in setuptools 3.0, and the "speedups" feature was removed from markupsafe in #23. Setuptools 3.1 restored "Features" (but they are deprecated), so adding them back here.

Fix #26 