### PR TITLE
Don't crash when calling Markup.format with objects that return non-ascii str()

### DIFF
--- a/markupsafe/__init__.py
+++ b/markupsafe/__init__.py
@@ -261,6 +261,8 @@ if hasattr(text_type, 'format'):
                 rv = value.__html__()
             else:
                 rv = string.Formatter.format_field(self, value, format_spec)
+                if isinstance(rv, bytes):
+                    rv = rv.decode('utf-8')
             return text_type(self.escape(rv))
 
 

--- a/markupsafe/tests.py
+++ b/markupsafe/tests.py
@@ -120,6 +120,17 @@ class MarkupTestCase(unittest.TestCase):
         assert Markup('<p>User: {0:link}').format(user) == \
             Markup('<p>User: <a href="/user/1"><span class=user>foo</span></a>')
 
+    def test_formatting_with_objects(self):
+        class Stringable(object):
+            def __str__(self):
+                return 'строка'
+
+            def __unicode__(self):
+                return u'строка'
+
+        assert Markup('{s}').format(s=Stringable()) == \
+            Markup(u'строка')
+
     def test_all_set(self):
         import markupsafe as markup
         for item in markup.__all__:


### PR DESCRIPTION
Notable example of such objects are Django's lazily-translated strings (`__proxy__` objects that get evaluated to strings in runtime)